### PR TITLE
[BUGFIX] TYPO3 7 compatibility & Cleanup

### DIFF
--- a/Configuration/TCA/Overrides/tx_kesearch_indexerconfig.php
+++ b/Configuration/TCA/Overrides/tx_kesearch_indexerconfig.php
@@ -1,0 +1,4 @@
+<?php
+// enable "sysfolder" and "startingpoints_recursive" field
+$GLOBALS['TCA']['tx_kesearch_indexerconfig']['columns']['sysfolder']['displayCond'] .= ',customindexer';
+$GLOBALS['TCA']['tx_kesearch_indexerconfig']['columns']['startingpoints_recursive']['displayCond'] .= ',customindexer';


### PR DESCRIPTION
Overriding TCA should now be done within Configuration/TCA/Overrides/
Enabled handling for recursive Pids
removed old code to render images (without FAL)