### PR TITLE
Use `extPath` instead of `extRelPath`

### DIFF
--- a/Classes/ExampleIndexer.php
+++ b/Classes/ExampleIndexer.php
@@ -26,7 +26,7 @@ class ExampleIndexer
         $customIndexer = array(
             '[CUSTOM] News-Indexer (ext:news)',
             $this->indexerConfigurationKey,
-            ExtensionManagementUtility::extRelPath('ke_search_hooks') . 'customnews-indexer-icon.gif'
+            ExtensionManagementUtility::extPath('ke_search_hooks') . 'customnews-indexer-icon.gif'
         );
         $params['items'][] = $customIndexer;
     }


### PR DESCRIPTION
The deprecation log says that the method `extRelPath` in ExtensionManagerUtility is deprecated with v8 and will be removed in v9. It is recommended to use `PathUtility::getAbsoluteWebPath()`, but PathUtility generates a wrong Path.

I compared these 3 options:
```
debug(PathUtility::getAbsoluteWebPath('rwfm_kesearch'), "PathUtility::getAbsoluteWebPath");
debug(ExtensionManagementUtility::extRelPath('rwfm_kesearch'), "ExtensionManagementUtility::extRelPath");
debug(ExtensionManagementUtility::extPath('rwfm_kesearch'), "ExtensionManagementUtility::extPath");
```
and got these 3 results:
```
'/typo3/rwfm_kesearch'
'../typo3conf/ext/rwfm_kesearch/'
'/Volumes/_II_/_SITES/[projectFolder]/typo3conf/ext/rwfm_kesearch/'
```

`PathUtility` yield to the wrong folder `typo3` and not `typo3conf/ext/`.

`extPath` works fine with this extension and is not deprecated.

Another solution would be to use a string:
`EXT:ke_search_hooks/customnews-indexer-icon.gif`